### PR TITLE
Adding Option to Read Bytes from Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/data

--- a/src/anl_module.rs
+++ b/src/anl_module.rs
@@ -252,7 +252,8 @@ where
             FileReadMethod::AllocBytes => {
                 let num_threads = self.threads;
                 let mut file_data: Vec<Vec<u8>> = vec![vec![]; num_threads];
-                let results: Arc<Mutex<Vec<Vec<R>>>> = Arc::new(Mutex::new(vec![vec![]; num_threads]));
+                let results: Arc<Mutex<Vec<Vec<R>>>> =
+                    Arc::new(Mutex::new(vec![vec![]; num_threads]));
                 let anl = anl_module.read().expect("Failed to get read lock");
                 println!("Threads:  {}", num_threads);
                 println!("Analyzing: {} files", paths.len());
@@ -265,14 +266,14 @@ where
                 // Parallelize over paths for now
                 let threaded_result_chunk = |start: usize, stop: usize, thread_idx: usize| {
                     let pb = pbar.add(ProgressBar::new((stop - start) as u64));
-                    let result = paths[start..stop].iter()
+                    let result = paths[start..stop]
+                        .iter()
                         // .progress_count((stop - start) as u64)
                         .filter(|path| path.to_str().unwrap().ends_with(".rkyv"))
                         .map(|path| {
                             let _ = &ptr;
-                            let mut fdata = unsafe {
-                                &mut (*ptr.0.clone().wrapping_add(thread_idx))
-                            };
+                            let mut fdata =
+                                unsafe { &mut (*ptr.0.clone().wrapping_add(thread_idx)) };
                             let mut f = File::open(path).unwrap();
                             fdata.clear();
                             f.read_to_end(&mut fdata).unwrap();
@@ -294,6 +295,7 @@ where
                     results.lock().unwrap().push(result);
                 };
 
+                // TODO: make this divide more evenly among threads
                 let chunk_size = paths.len() / num_threads;
                 let remainder = paths.len() % num_threads;
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use ebooa::anl_module::Anl;
 use ebooa::anl_module::AnlModule;
+use ebooa::anl_module::FileReadMethod;
 use ebooa::example_event::MyEvent;
 use indicatif::ParallelProgressIterator;
 use rayon::prelude::*;
@@ -78,6 +79,9 @@ struct Args {
     #[arg(short, long, default_value_t = 1_000)]
     files: usize,
 
+    #[arg(short, long)]
+    file_method: Option<FileReadMethod>,
+
     #[arg(short, long, default_value_t = 100_000)]
     events: usize,
 
@@ -113,9 +117,14 @@ fn main() {
 
     // read back files ... this is the stuff we are trying to make very very fast
     let module = TestAnlMod::default();
+    let mut anl = 
     Anl::<MyEvent, Res>::new()
         .with_input_directory(&args.data_dir)
         .with_anl_module(module)
-        .with_num_threads(args.threads)
+        .with_num_threads(args.threads);
+    if let Some(method) = args.file_method {
+        anl = anl.with_file_read_method(method);
+    }
+    anl
         .run();
 }


### PR DESCRIPTION
These changes introduce an option to Anl to choose which file method you want (mmap or read the bytes from the files). 

Wasn't sure whether the new field on Anl should be an optional or whether there should be a FileReadMethod::Heuristic enum value. I went with optional somewhat arbitrarily because it felt sensible to me after trying both. Though now we no longer get the nice chaining of build methods in test.rs.

Also unsure of naming on AllocBytes. There's probably something that makes more sense.

For the file read (which is multithreaded), I created a Vec<Vec<u8>> to store all the file data for each thread and index into it based on the current thread using some very safe Rust (tm).